### PR TITLE
carbon-sidebar-options-hide

### DIFF
--- a/apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
+++ b/apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
@@ -24,7 +24,7 @@ const PrimaryNavigation = () => {
 
     return acc;
   }, new Set<string>());
-
+  const hiddenModules: string[] = [];
   return (
     <div className="w-14 h-full flex-col z-50 hidden sm:flex">
       <nav
@@ -45,7 +45,9 @@ const PrimaryNavigation = () => {
           <VStack spacing={1}>
             {links.map((link) => {
               const m = getModule(link.to);
-
+              if (hiddenModules.includes(link.name)) {
+                return null;
+              }
               const moduleMatches = matchedModules.has(m);
 
               const isActive = currentModule === m || moduleMatches;


### PR DESCRIPTION
Task Summary:
Implemented a hiddenModules array in PrimaryNavigation.tsx to dynamically hide specific sidebar options by adding their names to the array. If the array is empty, all sidebar options are displayed.
Files Modified
1. apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
Expected Behavior
* Modules listed in the hiddenModules array should not render in the sidebar.
* If the hiddenModules array is empty, all modules should render normally.
Mandatory Tasks
* Code has been self-reviewed and cleaned up.
* No new ESLint warnings or errors.
* Verified sidebar behavior manually.




