### PR TITLE
sortup-918-User-getting-default-active-on-invite-fixed

### DIFF
--- a/packages/database/supabase/migrations/20251009091426_update_employees_view_with_status.sql
+++ b/packages/database/supabase/migrations/20251009091426_update_employees_view_with_status.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW "employees" WITH(SECURITY_INVOKER=true) AS
     u."avatarUrl",
     e."employeeTypeId",
     e."companyId",
-    u."active",
+    e."active",
     e."employeeStatusId"
   FROM "user" u
   INNER JOIN "employee" e


### PR DESCRIPTION
## What does this PR do?

Fixes employee status display issue where users showed as active without accepting invites.

## How should this be tested?

1. Create a new employee account
2. Verify the user shows as **unchecked** (inactive) with **red "UNAVAILABLE"** status
3. Accept the invite - user should show as **checked** (active) with **green "AVAILABLE"** status
4. Login/logout should update status correctly

## Changes Made

- Fixed `employees` view to use `e.active` instead of `u.active`
- Updated color scheme: Available (green), In Transit (yellow), Unavailable (red)
